### PR TITLE
shortened link to discussions

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -4,7 +4,7 @@ description: Components for Network Observability, unleashing eBPF super-power.
 name: NetObserv
 simple-name: NetObserv
 image: netobserv.svg
-social-github: netobserv/network-observability-operator/discussions
+social-github: netobserv/discussions
 social-mastodon: https://hachyderm.io/@netobserv 
 social-bluesky: netobserv.bsky.social
 social-twitter:

--- a/content/posts/2023-09-12-dns_tracking.md
+++ b/content/posts/2023-09-12-dns_tracking.md
@@ -146,4 +146,4 @@ The DNS flows display this information in both the table and the side panel:
 We hope you liked this article !
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2023-09-12-packet_drops.md
+++ b/content/posts/2023-09-12-packet_drops.md
@@ -184,4 +184,4 @@ significant (less than 3% increase).
 We hope you liked this article !
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2023-10-02-lokiless.md
+++ b/content/posts/2023-10-02-lokiless.md
@@ -286,4 +286,4 @@ We could also investigate other storage options. But as you can imagine, maintai
 
 Finally, if you feel inspired by this flow consumer app, but you would expect something directly usable out of the box, production-ready... Then, why not collaborate in the open? We would love to see open-source contributions on this field. We could for instance create new repositories for community-maintained connectors, hosted on NetObserv's GitHub, and would of course provide all the help and expertise that we can, if there is demand for that.
 
-Any other ideas, or something to say? Don't hesitate to comment or ask questions on [our discussion board](https://github.com/netobserv/network-observability-operator/discussions)! A thread has been created specifically for this blog post: [here](https://github.com/netobserv/network-observability-operator/discussions/438).
+Any other ideas, or something to say? Don't hesitate to comment or ask questions on [our discussion board](https://github.com/netobserv/discussions)! A thread has been created specifically for this blog post: [here](https://github.com/netobserv/discussions/438).

--- a/content/posts/2023-10-02-secondary_interface.md
+++ b/content/posts/2023-10-02-secondary_interface.md
@@ -154,4 +154,4 @@ packets as an example
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
 Feel free to share your
-[ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+[ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2023-12-05-acm.md
+++ b/content/posts/2023-12-05-acm.md
@@ -257,4 +257,4 @@ Be careful about escaping double-quotes, though it's not very pretty, it is nece
 
 Also, don't forget that NetObserv has [more metrics to show](https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md), especially starting from the coming-soon release 1.5, such as TCP latencies, [packet drop](https://cloud.redhat.com/blog/network-observability-real-time-per-flow-packets-drop) counters and so on. And just for teasing, we are working on a fresh new API in NetObserv that will soon let you build pretty much any metric you want out of flow logs, for even more dashboarding possibilities.
 
-If you want to get in touch with the NetObserv team, you can use our [discussion board](https://github.com/netobserv/network-observability-operator/discussions).
+If you want to get in touch with the NetObserv team, you can use our [discussion board](https://github.com/netobserv/discussions).

--- a/content/posts/2024-01-18-rtt.md
+++ b/content/posts/2024-01-18-rtt.md
@@ -162,4 +162,4 @@ Round Trip Time analysis:
 We hope you liked this article !
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2024-02-28-whats_new_1_5.md
+++ b/content/posts/2024-02-28-whats_new_1_5.md
@@ -184,4 +184,4 @@ When you create this instance or make any changes to FlowMetric, the flowlogs-pi
 
 ## Conclusion
 
-Hopefully, you are excited as I am on all the changes in this release.  I hope you get the chance to try it out, and let us know what you think!  You can always reach the NetObserv team on this [discussion board](https://github.com/netobserv/network-observability-operator/discussions).
+Hopefully, you are excited as I am on all the changes in this release.  I hope you get the chance to try it out, and let us know what you think!  You can always reach the NetObserv team on this [discussion board](https://github.com/netobserv/discussions).

--- a/content/posts/2024-07-25-cli.md
+++ b/content/posts/2024-07-25-cli.md
@@ -499,4 +499,4 @@ It could become 'yet another' toolset of observing and debugging tools such as [
 We hope you liked this article !
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2024-09-19-lokiless_netobserv.md
+++ b/content/posts/2024-09-19-lokiless_netobserv.md
@@ -158,6 +158,6 @@ In addition to metrics for the `DNSTracking` feature, Network Observability prov
 
 The Network Observability Operator provides the visibility you need to proactively detect issues within OpenShift cluster networking. Now with an option to disable Loki, and instead leverage Prometheus metrics, the Network Observability Operator provides a light-weight solution to visualize, diagnose and troubleshoot networking issues faster and at a lower cost. 
 
-Whether you have already deployed or considering to deploy Network Observability, we would love to engage with you and hear your thoughts [here](https://github.com/netobserv/network-observability-operator/discussions).
+Whether you have already deployed or considering to deploy Network Observability, we would love to engage with you and hear your thoughts [here](https://github.com/netobserv/discussions).
 
 _Special thanks to Joel Takvorian, Julien Pinsonneau, and Sara Thomas for providing information for this article._

--- a/content/posts/2024-10-18-network_events.md
+++ b/content/posts/2024-10-18-network_events.md
@@ -284,4 +284,4 @@ This helps you maintain a secure, high-performing network environment.
 
 We hope you liked this article !
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2024-10-23-whats_new_1_6.md
+++ b/content/posts/2024-10-23-whats_new_1_6.md
@@ -216,7 +216,7 @@ To stop the program, press ctrl-C.  More information about NetObserv CLI will be
 
 If you are hesitant about deploying Network Observability, fear not.  With Network Observability CLI, you can experiment and have it completely removed when you are done using it.  The second option lets you install Network Observability without Loki, while still providing the majority of the features of this operator.
 
-What are you waiting for?  Give it a try, and let us know what you think on the [discussion board](https://github.com/netobserv/network-observability-operator/discussions).
+What are you waiting for?  Give it a try, and let us know what you think on the [discussion board](https://github.com/netobserv/discussions).
 
 ---
 

--- a/content/posts/2024-11-07-whats_new_1_7.md
+++ b/content/posts/2024-11-07-whats_new_1_7.md
@@ -167,7 +167,7 @@ The Frame 6 row is selected and highlighted in blue.  In the Packet Details sect
 
 ## Closing
 
-There are a lot of features packed into this release.  Spend the time to experiment with the features, and let us know how it helps you perform your tasks.  If you have any comments or suggestions, you can contact us on the [discussion board](https://github.com/netobserv/network-observability-operator/discussions).
+There are a lot of features packed into this release.  Spend the time to experiment with the features, and let us know how it helps you perform your tasks.  If you have any comments or suggestions, you can contact us on the [discussion board](https://github.com/netobserv/discussions).
 
 ---
 

--- a/content/posts/2025-01-03-packets-xlation-enrichment.md
+++ b/content/posts/2025-01-03-packets-xlation-enrichment.md
@@ -205,4 +205,4 @@ and enhance security.
 
 We hope you liked this article!
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2025-02-11-cli_whats_new_1.8.md
+++ b/content/posts/2025-02-11-cli_whats_new_1.8.md
@@ -235,4 +235,4 @@ filters:
 We hope you enjoyed this article!
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2025-02-12-ebpf_flow_filtering.md
+++ b/content/posts/2025-02-12-ebpf_flow_filtering.md
@@ -269,4 +269,4 @@ This approach is critical for scalability, cost reduction, and real-time network
 
 We hope you liked this article!
 Netobserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/content/posts/2025-02-14-cli_use_cases.md
+++ b/content/posts/2025-02-14-cli_use_cases.md
@@ -371,4 +371,4 @@ Open the mitm proxy url and generate a query to your route. You can see queries 
 We hope you enjoyed this article!
 
 NetObserv is an open source project [available on github](https://github.com/netobserv).
-Feel free to share your [ideas](https://github.com/netobserv/network-observability-operator/discussions/categories/ideas), [use cases](https://github.com/netobserv/network-observability-operator/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/network-observability-operator/discussions/categories/q-a).
+Feel free to share your [ideas](https://github.com/netobserv/discussions/categories/ideas), [use cases](https://github.com/netobserv/discussions/categories/show-and-tell) or [ask the community for help](https://github.com/netobserv/discussions/categories/q-a).

--- a/data/events.yml
+++ b/data/events.yml
@@ -9,4 +9,4 @@
 - title: "NetObserv birth"
   description: "This was the first release of the NetObserv operator on OperatorHub!"
   date: "2022-02-14"
-  link: https://github.com/netobserv/network-observability-operator/discussions/56
+  link: https://github.com/netobserv/discussions/56


### PR DESCRIPTION
FYI I just saw that we can create an org level discussion page, which is just a shortcut to the repo-level discussion.

So instead of sharing links to https://github.com/netobserv/network-observability-operator/discussions we can shorten it to  https://github.com/orgs/netobserv/discussions - that's really the same, we don't have to migrate the current content.